### PR TITLE
Build: Fix install configuration and versioning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,11 @@ props.load(new FileInputStream("$projectDir/all-modules.properties"))
 project.ext.allModuleNames = props['modules.common.all']
 project.ext.modulesDistsDir = file("${project.buildDir}/modulesZip")
 
+// Jenkins sets BUILD_NUMBER incrementally. It can be overridden in the command line
+//  (E.g.: ./gradlew -Pbuild_number=127 info). If not provided, it gets a default 'manual'
+String buildNumber = project.hasProperty('build_number') ? build_number
+        : (System.env["BUILD_NUMBER"] ?: 'manual')
+
 repositories {
     mavenLocal()
     if (project.hasProperty('additional_repositories')){
@@ -338,12 +343,78 @@ install {
     }
 }
 
+// Configure zip artifacts for publishing
+if (project.hasProperty('publish_repository')) {
+    // Add all distributables modules
+    artifacts {
+        tasks.findAll { task -> task.name.startsWith('dist_') }.each { distTask ->
+            archives distTask
+        }
+    }
+
+    uploadArchives {
+        repositories {
+            mavenDeployer {
+                repository(url: publish_repository) {
+                    authentication(userName: publish_user, password: publish_password)
+                }
+                tasks.findAll { task -> task.name.startsWith('dist_') }.each { distTask ->
+                    // E.g. distTask ":dist_org.opencms.apollo.template.core"
+                    //    distTask.baseName = "org.opencms.apollo.template.core"
+                    String filterName = distTask.baseName
+                    addFilter(filterName) { artifact, file ->
+                        // E.g. artifact:
+                        //    artifact.name = "org.opencms.apollo.template.core"
+                        //    artifact.ext = "zip"
+                        //    artifact.type = "zip"
+                        artifact.name == filterName
+                    }
+                    pom(filterName).project {
+                        name "The OpenCms Apollo Template - $filterName"
+                        version = "${distTask.version}.${buildNumber}"
+                        description "The OpenCms Apollo Template - $filterName"
+                        packaging 'zip'
+                        groupId 'org.opencms'
+                        url 'http://www.alkacon.com'
+                        scm {
+                            url 'scm:git@github.com:alkacon/apollo-template.git'
+                            connection 'scm:git@github.com:alkacon/apollo-template.git'
+                            developerConnection 'scm:git@github.com:alkacon/apollo-template.git'
+                        }
+                        licenses {
+                            license {
+                                name 'GNU General Public License'
+                                url 'http://www.gnu.org/licenses/gpl.html'
+                                distribution 'repo'
+                            }
+                        }
+                        organization {
+                            name 'Alkacon Software'
+                            url 'http://www.alkacon.com'
+                        }
+                        developers {
+                            developer {
+                                name 'Alkacon Software'
+                                url 'http://www.alkacon.com'
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 // Configure versioning for jar artifacts
 tasks.findAll { task -> task.name.startsWith('jar_org.opencms.') }.each { jarTask ->
     String filterName = jarTask.baseName
+    def uploaders = [install.repositories.mavenInstaller]
+    if (project.hasProperty('publish_repository')) {
+        uploaders << uploadArchives.repositories.mavenDeployer
+    }
 
-    install.repositories.mavenInstaller.pom(filterName)*.project {
-        version = jarTask.moduleVersion
+    uploaders*.pom(filterName)*.project {
+        version = "${jarTask.moduleVersion}.${buildNumber}"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -284,7 +284,7 @@ tasks.withType(JavaCompile) {
 }
 artifacts {
     tasks.each{ task ->
-        if (task.name.startsWith("jar_com.alkacon.")){
+        if (task.name.startsWith("jar_org.opencms.")){
             def moduleName=task.baseName
             archives task
             archives tasks["javadocJar_$moduleName"]
@@ -298,21 +298,21 @@ install {
         mavenInstaller {
             artifacts.each{ arch ->
                 def filterName=arch.name
-                if (filterName.startsWith("com.alkacon")){
+                if (filterName.startsWith("org.opencms") && filterName.endsWith(".jar")){
                     filterName=filterName.substring(0, filterName.lastIndexOf(".jar"))
                     addFilter(filterName){artifact, file ->
                         artifact.name.startsWith(filterName)
                     }
                     pom(filterName).project {
-                        name 'Alkacon OAMP'
-                        description 'Alkacon OAMP'
+                        name "The OpenCms Apollo Template - $filterName"
+                        description "The OpenCms Apollo Template - $filterName"
                         packaging 'jar'
-                        groupId 'com.alkacon'
+                        groupId 'org.opencms'
                         url 'http://www.alkacon.com'
                         scm {
-                            url 'scm:git@github.com:alkacon/alkacon-oamp.git'
-                            connection 'scm:git@github.com:alkacon/alkacon-oamp.git'
-                            developerConnection 'scm:git@github.com:alkacon/alkacon-oamp.git'
+                            url 'scm:git@github.com:alkacon/apollo-template.git'
+                            connection 'scm:git@github.com:alkacon/apollo-template.git'
+                            developerConnection 'scm:git@github.com:alkacon/apollo-template.git'
                         }
                         licenses {
                             license {
@@ -335,5 +335,22 @@ install {
                 }
             }
         }
+    }
+}
+
+// Configure versioning for jar artifacts
+tasks.findAll { task -> task.name.startsWith('jar_org.opencms.') }.each { jarTask ->
+    String filterName = jarTask.baseName
+
+    install.repositories.mavenInstaller.pom(filterName)*.project {
+        version = jarTask.moduleVersion
+    }
+}
+
+tasks.withType(Javadoc) {
+    options.addStringOption("sourcepath", "")
+    if (JavaVersion.current().isJava8Compatible()) {
+    	options.addStringOption("Xdoclint:none", "-quiet")
+    	options.addBooleanOption("-allow-script-in-comments",true);
     }
 }


### PR DESCRIPTION
The install task was configured using copy-pasted config from the oamp module.
The jars are missing the versioning information.
Configure uploadArchives analog to how opencms-core build does. (No signature yet.)